### PR TITLE
Store Weak Reference to Players

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,10 +131,6 @@
             <url>https://repo.codemc.io/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
-        </repository>
-        <repository>
             <id>essentials-releases</id>
             <url>https://repo.essentialsx.net/releases/</url>
         </repository>

--- a/src/main/java/io/myzticbean/finditemaddon/handlers/command/CmdExecutorHandler.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/command/CmdExecutorHandler.java
@@ -55,147 +55,94 @@ public class CmdExecutorHandler {
     public void handleShopSearch(String buySellSubCommand, CommandSender commandSender, String itemArg) {
         if (!(commandSender instanceof Player player)) {
             Logger.logInfo(THIS_COMMAND_CAN_ONLY_BE_RUN_FROM_IN_GAME);
+            return;
+        } else if (player.hasPermission(PlayerPermsEnum.FINDITEM_USE.value())) {
+            player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + "&cNo permission!"));
+            return;
+        }
+
+        // Show searching... message
+        if (!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().SHOP_SEARCH_LOADING_MSG)) {
+            player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().SHOP_SEARCH_LOADING_MSG));
+        }
+
+        boolean isBuying;
+        if(StringUtils.isEmpty(FindItemAddOn.getConfigProvider().FIND_ITEM_TO_BUY_AUTOCOMPLETE) || StringUtils.containsIgnoreCase(FindItemAddOn.getConfigProvider().FIND_ITEM_TO_BUY_AUTOCOMPLETE, " ")) {
+            isBuying = buySellSubCommand.equalsIgnoreCase("to_buy");
         }
         else {
-            if(player.hasPermission(PlayerPermsEnum.FINDITEM_USE.value())) {
+            isBuying = buySellSubCommand.equalsIgnoreCase(FindItemAddOn.getConfigProvider().FIND_ITEM_TO_BUY_AUTOCOMPLETE);
+        }
 
-                // Show searching... message
-                if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().SHOP_SEARCH_LOADING_MSG)) {
-                    player.sendMessage(ColorTranslator.translateColorCodes(
-                            FindItemAddOn.getConfigProvider().PLUGIN_PREFIX
-                                    + FindItemAddOn.getConfigProvider().SHOP_SEARCH_LOADING_MSG));
-                }
 
-                boolean isBuying;
-                if(StringUtils.isEmpty(FindItemAddOn.getConfigProvider().FIND_ITEM_TO_BUY_AUTOCOMPLETE)
-                        || StringUtils.containsIgnoreCase(FindItemAddOn.getConfigProvider().FIND_ITEM_TO_BUY_AUTOCOMPLETE, " ")) {
-                    isBuying = buySellSubCommand.equalsIgnoreCase("to_buy");
-                }
-                else {
-                    isBuying = buySellSubCommand.equalsIgnoreCase(FindItemAddOn.getConfigProvider().FIND_ITEM_TO_BUY_AUTOCOMPLETE);
-                }
 
-                if(itemArg.equalsIgnoreCase("*") && !FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_DISABLE_SEARCH_ALL_SHOPS) {
-                    // If QS Hikari installed and Shop Cache feature available (>6), then run in async thread (Fix for Issue #12)
-                    if(!FindItemAddOn.isQSReremakeInstalled() && FindItemAddOn.getQsApiInstance().isQSShopCacheImplemented()) {
-                        Logger.logDebugInfo("Should run in async thread...");
-                        Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
-                            List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().fetchAllItemsFromAllShops(isBuying, player);
-                            if(!searchResultList.isEmpty()) {
-                                Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
-                                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                    menu.open(searchResultList);
-                                });
-                            }
-                            else {
-                                if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
-                                    player.sendMessage(ColorTranslator.translateColorCodes(
-                                            FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG));
-                                }
-                            }
-                        });
-                    } else {
-                        // Else run in MAIN thread
-                        List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().fetchAllItemsFromAllShops(isBuying, player);
-                        if(!searchResultList.isEmpty()) {
-                            FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                            Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
-                        }
-                        else {
-                            if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
-                                player.sendMessage(ColorTranslator.translateColorCodes(
-                                        FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG));
-                            }
-                        }
-                    }
-                }
-                else {
-                    Material mat = Material.getMaterial(itemArg.toUpperCase());
-                    if(checkMaterialBlacklist(mat, player)) {
-                        player.sendMessage(ColorTranslator.translateColorCodes(
-                            FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + "&cThis material is not allowed."));
-                        return;
-                    }
-                    if(mat != null) {
-                        Logger.logDebugInfo("Material found: " + mat);
-                        // If QS Hikari installed and Shop Cache feature available (>6), then run in async thread (Fix for Issue #12)
-                        if(!FindItemAddOn.isQSReremakeInstalled() && FindItemAddOn.getQsApiInstance().isQSShopCacheImplemented()) {
-                            Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
-                                List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnTypeFromAllShops(new ItemStack(mat), isBuying, player);
-                                if(!searchResultList.isEmpty()) {
-                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
-                                        FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                        menu.open(searchResultList);
-                                    });
-                                }
-                                else {
-                                    if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
-                                        player.sendMessage(ColorTranslator.translateColorCodes(
-                                                FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG));
-                                    }
-                                }
-                            });
-                        } else {
-                            List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnTypeFromAllShops(new ItemStack(mat), isBuying, player);
-                            if(!searchResultList.isEmpty()) {
-                                Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
-                                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                    menu.open(searchResultList);
-                                });
-                            }
-                            else {
-                                if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
-                                    player.sendMessage(ColorTranslator.translateColorCodes(
-                                            FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG));
-                                }
-                            }
-                        }
-                    }
-                    else {
-                        Logger.logDebugInfo("Material not found! Performing query based search..");
-                        // If QS Hikari installed and Shop Cache feature available (>6), then run in async thread (Fix for Issue #12)
-                        if(!FindItemAddOn.isQSReremakeInstalled() && FindItemAddOn.getQsApiInstance().isQSShopCacheImplemented()) {
-                            Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
-                                List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnDisplayNameFromAllShops(itemArg, isBuying, player);
-                                if(!searchResultList.isEmpty()) {
-                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
-                                        FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                        menu.open(searchResultList);
-                                    });
-                                }
-                                else {
-                                    // Invalid Material
-                                    if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_INVALID_MATERIAL_MSG)) {
-                                        player.sendMessage(ColorTranslator.translateColorCodes(
-                                                FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_INVALID_MATERIAL_MSG));
-                                    }
-                                }
-                            });
-                        } else {
-                            List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnDisplayNameFromAllShops(itemArg, isBuying, player);
-                            if(!searchResultList.isEmpty()) {
-                                FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                menu.open(searchResultList);
-                            }
-                            else {
-                                // Invalid Material
-                                if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_INVALID_MATERIAL_MSG)) {
-                                    player.sendMessage(ColorTranslator.translateColorCodes(
-                                            FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_INVALID_MATERIAL_MSG));
-                                }
-                            }
-                        }
-                    }
-                }
-
+        if(itemArg.equalsIgnoreCase("*") && !FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_DISABLE_SEARCH_ALL_SHOPS) {
+            // If QS Hikari installed and Shop Cache feature available (>6), then run in async thread (Fix for Issue #12)
+            if(!FindItemAddOn.isQSReremakeInstalled() && FindItemAddOn.getQsApiInstance().isQSShopCacheImplemented()) {
+                Logger.logDebugInfo("Should run in async thread...");
+                Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
+                    List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().fetchAllItemsFromAllShops(isBuying, player);
+                    this.openShopMenu(player, searchResultList, true, FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG);
+                });
+            } else {
+                // Else run in MAIN thread
+                List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().fetchAllItemsFromAllShops(isBuying, player);
+                this.openShopMenu(player, searchResultList, false, FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG);
             }
-            else {
-                player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + "&cNo permission!"));
+        } else {
+            Material mat = Material.getMaterial(itemArg.toUpperCase());
+            if(this.checkMaterialBlacklist(mat)) {
+                player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + "&cThis material is not allowed."));
+                return;
+            }
+            if (mat != null) {
+                Logger.logDebugInfo("Material found: " + mat);
+                // If QS Hikari installed and Shop Cache feature available (>6), then run in async thread (Fix for Issue #12)
+                if(!FindItemAddOn.isQSReremakeInstalled() && FindItemAddOn.getQsApiInstance().isQSShopCacheImplemented()) {
+                    Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
+                        List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnTypeFromAllShops(new ItemStack(mat), isBuying, player);
+                        this.openShopMenu(player, searchResultList, true, FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG);
+                    });
+                } else {
+                    List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnTypeFromAllShops(new ItemStack(mat), isBuying, player);
+                    this.openShopMenu(player, searchResultList, false, FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG);
+                }
+            } else {
+                Logger.logDebugInfo("Material not found! Performing query based search..");
+                // If QS Hikari installed and Shop Cache feature available (>6), then run in async thread (Fix for Issue #12)
+                if(!FindItemAddOn.isQSReremakeInstalled() && FindItemAddOn.getQsApiInstance().isQSShopCacheImplemented()) {
+                    Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
+                        List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnDisplayNameFromAllShops(itemArg, isBuying, player);
+                        this.openShopMenu(player, searchResultList, true, FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_INVALID_MATERIAL_MSG);
+                    });
+                } else {
+                    List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnDisplayNameFromAllShops(itemArg, isBuying, player);
+                    this.openShopMenu(player, searchResultList, false, FindItemAddOn.getConfigProvider().FIND_ITEM_CMD_INVALID_MATERIAL_MSG);
+                }
             }
         }
     }
 
-    private boolean checkMaterialBlacklist(Material mat, Player player) {
+    private void openShopMenu(Player player, List<FoundShopItemModel> searchResultList, boolean synchronize, String errorMsg) {
+        if (!searchResultList.isEmpty()) {
+            if (synchronize) {
+                Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
+                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                    menu.open(searchResultList);
+                });
+            } else {
+                FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                menu.open(searchResultList);
+            }
+        } else {
+            Logger.logInfo("Couldn't find any shops for: " + player.getName());
+            if (!StringUtils.isEmpty(errorMsg)) {
+                player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + errorMsg));
+            }
+        }
+    }
+
+    private boolean checkMaterialBlacklist(Material mat) {
         return FindItemAddOn.getConfigProvider().getBlacklistedMaterials().contains(mat);
     }
 

--- a/src/main/java/io/myzticbean/finditemaddon/handlers/command/CmdExecutorHandler.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/command/CmdExecutorHandler.java
@@ -56,7 +56,8 @@ public class CmdExecutorHandler {
         if (!(commandSender instanceof Player player)) {
             Logger.logInfo(THIS_COMMAND_CAN_ONLY_BE_RUN_FROM_IN_GAME);
             return;
-        } else if (player.hasPermission(PlayerPermsEnum.FINDITEM_USE.value())) {
+        }
+        if (!player.hasPermission(PlayerPermsEnum.FINDITEM_USE.value())) {
             player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + "&cNo permission!"));
             return;
         }
@@ -205,13 +206,13 @@ public class CmdExecutorHandler {
      * @param commandSender Who is the command sender: console or player
      */
     public void handlePluginReload(CommandSender commandSender) {
-        if (!(commandSender instanceof Player)) {
+        if (!(commandSender instanceof Player player)) {
             ConfigSetup.reloadConfig();
             ConfigSetup.checkForMissingProperties();
             ConfigSetup.saveConfig();
             FindItemAddOn.initConfigProvider();
-            List allServerShops = FindItemAddOn.getQsApiInstance().getAllShops();
-            if(allServerShops.size() == 0) {
+            List<Shop> allServerShops = FindItemAddOn.getQsApiInstance().getAllShops();
+            if(allServerShops.isEmpty()) {
                 Logger.logWarning("&6Found &e0 &6shops on the server. If you ran &e/qs reload &6recently, please restart your server!");
             }
             else {
@@ -220,7 +221,6 @@ public class CmdExecutorHandler {
             WarpUtils.updateWarps();
         }
         else {
-            Player player = (Player) commandSender;
             if(player.hasPermission(PlayerPermsEnum.FINDITEM_RELOAD.value()) || player.hasPermission(PlayerPermsEnum.FINDITEM_ADMIN.value())) {
                 ConfigSetup.reloadConfig();
                 ConfigSetup.checkForMissingProperties();
@@ -228,7 +228,7 @@ public class CmdExecutorHandler {
                 FindItemAddOn.initConfigProvider();
                 player.sendMessage(ColorTranslator.translateColorCodes(FindItemAddOn.getConfigProvider().PLUGIN_PREFIX + "&aConfig reloaded!"));
                 List allServerShops = FindItemAddOn.getQsApiInstance().getAllShops();
-                if(allServerShops.size() == 0) {
+                if(allServerShops.isEmpty()) {
                     player.sendMessage(ColorTranslator.translateColorCodes(
                             FindItemAddOn.getConfigProvider().PLUGIN_PREFIX
                                     + "&6Found &e0 &6shops on the server. If you ran &e/qs reload &6recently, please restart your server!"));

--- a/src/main/java/io/myzticbean/finditemaddon/handlers/command/CmdExecutorHandler.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/command/CmdExecutorHandler.java
@@ -82,8 +82,10 @@ public class CmdExecutorHandler {
                         Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
                             List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().fetchAllItemsFromAllShops(isBuying, player);
                             if(!searchResultList.isEmpty()) {
-                                FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
+                                Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
+                                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                                    menu.open(searchResultList);
+                                });
                             }
                             else {
                                 if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
@@ -96,10 +98,8 @@ public class CmdExecutorHandler {
                         // Else run in MAIN thread
                         List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().fetchAllItemsFromAllShops(isBuying, player);
                         if(!searchResultList.isEmpty()) {
-                            Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
-                                FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
-                            });
+                            FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                            Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
                         }
                         else {
                             if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
@@ -123,8 +123,10 @@ public class CmdExecutorHandler {
                             Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
                                 List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnTypeFromAllShops(new ItemStack(mat), isBuying, player);
                                 if(!searchResultList.isEmpty()) {
-                                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
+                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
+                                        FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                                        menu.open(searchResultList);
+                                    });
                                 }
                                 else {
                                     if(!StringUtils.isEmpty(FindItemAddOn.getConfigProvider().NO_SHOP_FOUND_MSG)) {
@@ -138,7 +140,7 @@ public class CmdExecutorHandler {
                             if(!searchResultList.isEmpty()) {
                                 Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
                                     FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
+                                    menu.open(searchResultList);
                                 });
                             }
                             else {
@@ -156,8 +158,10 @@ public class CmdExecutorHandler {
                             Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
                                 List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnDisplayNameFromAllShops(itemArg, isBuying, player);
                                 if(!searchResultList.isEmpty()) {
-                                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
+                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> {
+                                        FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                                        menu.open(searchResultList);
+                                    });
                                 }
                                 else {
                                     // Invalid Material
@@ -170,10 +174,8 @@ public class CmdExecutorHandler {
                         } else {
                             List<FoundShopItemModel> searchResultList = FindItemAddOn.getQsApiInstance().findItemBasedOnDisplayNameFromAllShops(itemArg, isBuying, player);
                             if(!searchResultList.isEmpty()) {
-                                Bukkit.getScheduler().runTaskAsynchronously(FindItemAddOn.getInstance(), () -> {
-                                    FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
-                                    Bukkit.getScheduler().runTask(FindItemAddOn.getInstance(), () -> menu.open(searchResultList));
-                                });
+                                FoundShopsMenu menu = new FoundShopsMenu(FindItemAddOn.getPlayerMenuUtility(player), searchResultList);
+                                menu.open(searchResultList);
                             }
                             else {
                                 // Invalid Material
@@ -194,8 +196,7 @@ public class CmdExecutorHandler {
     }
 
     private boolean checkMaterialBlacklist(Material mat, Player player) {
-        if(FindItemAddOn.getConfigProvider().getBlacklistedMaterials().contains(mat)) return true;
-        return false;
+        return FindItemAddOn.getConfigProvider().getBlacklistedMaterials().contains(mat);
     }
 
     /**

--- a/src/main/java/io/myzticbean/finditemaddon/handlers/gui/Menu.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/gui/Menu.java
@@ -20,6 +20,7 @@ package io.myzticbean.finditemaddon.handlers.gui;
 
 import io.myzticbean.finditemaddon.FindItemAddOn;
 import io.myzticbean.finditemaddon.models.FoundShopItemModel;
+import io.myzticbean.finditemaddon.utils.log.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -80,6 +81,7 @@ public abstract class Menu implements InventoryHolder {
         inventory = Bukkit.createInventory(this, getSlots(), getMenuName());
         this.setMenuItems(foundShops);
         playerMenuUtility.getOwner().openInventory(inventory);
+        Logger.logInfo("Opening inventory for player: " + playerMenuUtility.getOwner().getName());
     }
 
     @NotNull

--- a/src/main/java/io/myzticbean/finditemaddon/handlers/gui/PlayerMenuUtility.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/gui/PlayerMenuUtility.java
@@ -19,35 +19,43 @@
 package io.myzticbean.finditemaddon.handlers.gui;
 
 import io.myzticbean.finditemaddon.models.FoundShopItemModel;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @author myzticbean
  */
 public class PlayerMenuUtility {
-    private Player owner;
+    private UUID owner;
 
+    @Setter
+    @Getter
     private List<FoundShopItemModel> playerShopSearchResult;
 
-    public List<FoundShopItemModel> getPlayerShopSearchResult() {
-        return playerShopSearchResult;
-    }
-
-    public void setPlayerShopSearchResult(List<FoundShopItemModel> playerShopSearchResult) {
-        this.playerShopSearchResult = playerShopSearchResult;
-    }
-
     public PlayerMenuUtility(Player owner) {
+        this.owner = owner.getUniqueId();
+    }
+
+    public PlayerMenuUtility(UUID owner) {
         this.owner = owner;
     }
 
+    @Nullable
     public Player getOwner() {
-        return owner;
+        return Bukkit.getPlayer(owner);
     }
 
     public void setOwner(Player owner) {
+        this.owner = owner.getUniqueId();
+    }
+
+    public void setOwner(UUID owner) {
         this.owner = owner;
     }
 }


### PR DESCRIPTION
Hi, I was having some issues on my Minecraft server where players were reporting that `/searchshop` wasn't working, but seemingly at random. After a few weeks, I narrowed down the issue to players relogging. Once a player relogs from the server, the `Player` object used in PlayerMenuUtility becomes stale and no longer points to the new Player object. I replaced `owner` with a reference to the player's UUID and had the `getPlayer()` method now gets the new player object straight from Bukkit.

I also did a bit of cleanup in the handler class for `/searchshop` when I was searching for this bug.

I've only discovered, and tested this bug/fix on MC 1.21.4.