### PR TITLE
Fixed a bug teleporting to a shop without essentials

### DIFF
--- a/src/main/java/io/myzticbean/finditemaddon/handlers/gui/menus/FoundShopsMenu.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/gui/menus/FoundShopsMenu.java
@@ -219,7 +219,8 @@ public class FoundShopsMenu extends PaginatedMenu {
 
         // Record the visit and set last location for Essentials
         ShopSearchActivityStorageUtil.addPlayerVisitEntryAsync(shopLocation, player);
-        EssentialsXPlugin.setLastLocation(player);
+        if (EssentialsXPlugin.isEnabled())
+            EssentialsXPlugin.setLastLocation(player);
 
         // Apply teleport delay if necessary, otherwise teleport immediately
         if (shouldApplyTeleportDelay(player)) {


### PR DESCRIPTION
Trying to teleport to a shop without essentials gave this error:
```
[20:35:10 ERROR]: Could not pass event InventoryClickEvent to QSFindItemAddOn v2.0.7.4-RELEASE
java.lang.NoClassDefFoundError: com/earth2me/essentials/Essentials
        at QSFindItemAddOn-2.0.7.4-RELEASE.jar/io.myzticbean.finditemaddon.dependencies.EssentialsXPlugin.setLastLocation(EssentialsXPlugin.java:98) ~[QSFindItemAddOn-2.0.7.4-RELEASE.jar:?]
        at QSFindItemAddOn-2.0.7.4-RELEASE.jar/io.myzticbean.finditemaddon.handlers.gui.menus.FoundShopsMenu.handleDirectShopTeleport(FoundShopsMenu.java:222) ~[QSFindItemAddOn-2.0.7.4-RELEASE.jar:?]
        at QSFindItemAddOn-2.0.7.4-RELEASE.jar/io.myzticbean.finditemaddon.handlers.gui.menus.FoundShopsMenu.handleShopItemClick(FoundShopsMenu.java:175) ~[QSFindItemAddOn-2.0.7.4-RELEASE.jar:?]
        at QSFindItemAddOn-2.0.7.4-RELEASE.jar/io.myzticbean.finditemaddon.handlers.gui.menus.FoundShopsMenu.handleMenu(FoundShopsMenu.java:121) ~[QSFindItemAddOn-2.0.7.4-RELEASE.jar:?]
        at QSFindItemAddOn-2.0.7.4-RELEASE.jar/io.myzticbean.finditemaddon.listeners.MenuListener.onMenuClick(MenuListener.java:40) ~[QSFindItemAddOn-2.0.7.4-RELEASE.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3188) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:69) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:29) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1448) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1428) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1422) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1379) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1387) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1264) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.4.jar:1.21.4-121-88bbead]
        at java.base/java.lang.Thread.run(Unknown Source) ~[?:?]
Caused by: java.lang.ClassNotFoundException: com.earth2me.essentials.Essentials
        at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:197) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:164) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
        ... 28 more
```


This pull request checks if essentials is enabled before setting the last location.