### PR TITLE
Change comma delimiter to triple pipe

### DIFF
--- a/src/main/java/io/myzticbean/finditemaddon/handlers/gui/menus/FoundShopsMenu.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/gui/menus/FoundShopsMenu.java
@@ -168,7 +168,7 @@ public class FoundShopsMenu extends PaginatedMenu {
         }
 
         String locData = meta.getPersistentDataContainer().get(key, PersistentDataType.STRING);
-        List<String> locDataList = Arrays.asList(locData.split("\\s*,\\s*"));
+        List<String> locDataList = Arrays.asList(locData.split("\\s*\\|\\|\\|\\s*"));
 
         // Handle direct teleportation to shop
         if (configProvider.TP_PLAYER_DIRECTLY_TO_SHOP && locDataList.size() > 1) {
@@ -586,7 +586,7 @@ public class FoundShopsMenu extends PaginatedMenu {
         if (configProvider.TP_PLAYER_DIRECTLY_TO_SHOP) {
             // Store exact coordinates for direct teleportation
             Location shopLoc = foundShop.getShopLocation();
-            locData = String.format("%s,%d,%d,%d", shopLoc.getWorld().getName(), shopLoc.getBlockX(),
+            locData = String.format("%s|||%d|||%d|||%d", shopLoc.getWorld().getName(), shopLoc.getBlockX(),
                     shopLoc.getBlockY(), shopLoc.getBlockZ());
         } else if (configProvider.TP_PLAYER_TO_NEAREST_WARP) {
             // Store nearest warp info for warp teleportation


### PR DESCRIPTION
This pull request updates how shop location data is serialized and deserialized in the `FoundShopsMenu` class to improve parsing reliability. The delimiter used to separate location data fields has been changed from a comma to a unique string sequence.

**Location Data Serialization and Parsing:**

* Changed the delimiter for shop location data from a comma (`,`) to a triple pipe (`|||`) in both serialization (`setLocationData`) and deserialization (`handleShopItemClick`). This reduces the risk of parsing errors if any field contains a comma. 
* Player Warp names can contain `,` and some shops use `Stone,Wood,More!` as their shop name. 
* Technically a shop name can contain `|||`, but it is less likely 