### PR TITLE
Fix: added null check for BentoBox to stop infinite searching

### DIFF
--- a/src/main/java/io/myzticbean/finditemaddon/quickshop/impl/QSHikariAPIHandler.java
+++ b/src/main/java/io/myzticbean/finditemaddon/quickshop/impl/QSHikariAPIHandler.java
@@ -458,11 +458,12 @@ public class QSHikariAPIHandler implements QSApi<QuickShop, Shop> {
     private void processPotentialShopMatchAndAddToFoundList(boolean toBuy, Shop shopIterator, List<FoundShopItemModel> shopsFoundList, Player searchingPlayer) {
         Logger.logDebugInfo("Shop match found: " + shopIterator.getLocation());
         // Check if shop is in a locked BentoBox island
-        if (FindItemAddOn.getConfigProvider().BENTOBOX_IGNORE_LOCKED_ISLAND_SHOPS && 
-            FindItemAddOn.getBentoboxPlugin().isIslandLocked(shopIterator.getLocation(), searchingPlayer)) {
-            Logger.logDebugInfo("Shop is in locked BentoBox island - ignoring");
+        if (FindItemAddOn.getConfigProvider().BENTOBOX_IGNORE_LOCKED_ISLAND_SHOPS &&
+                 FindItemAddOn.getBentoboxPlugin() != null &&
+                 FindItemAddOn.getBentoboxPlugin().isIslandLocked(shopIterator.getLocation(), searchingPlayer)) {
+                 Logger.logDebugInfo("Shop is in locked BentoBox island - ignoring");
             return;
-        }
+            }
         // check for stock / space
         int stockOrSpace = (toBuy ? getRemainingStockOrSpaceFromShopCache(shopIterator, true)
                 : getRemainingStockOrSpaceFromShopCache(shopIterator, false));


### PR DESCRIPTION
QSFindItemAddOn throws a NullPointerException if BentoBox is not installed, causing /finditem to get stuck at "Searching..." forever.

### Solution
Added a null check before calling `isIslandLocked()` on BentoBoxPlugin. This prevents the async search task from crashing and allows the GUI to display search results normally.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crash when the BentoBox plugin is not installed, improving stability and reliability when searching for shops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->