### PR TITLE
Use FoliaLib teleportAsync directly in PlayerUtil

### DIFF
--- a/src/main/java/io/myzticbean/finditemaddon/utils/PlayerUtil.java
+++ b/src/main/java/io/myzticbean/finditemaddon/utils/PlayerUtil.java
@@ -22,14 +22,9 @@ public class PlayerUtil {
 
     @SneakyThrows
     public void teleport(Player player, Location locToTeleport) {
-        // FindItemAddOn.getScheduler().teleportAsync(player, locToTeleport, PlayerTeleportEvent.TeleportCause.PLUGIN);
-        // TODO: Teleportation not working on Folia servers, needs a fix
-        FindItemAddOn.getScheduler().runAtEntity(player, (t) ->
-                player
-                        .teleportAsync(locToTeleport, PlayerTeleportEvent.TeleportCause.PLUGIN)
-                        .thenAcceptAsync(isTeleported -> Logger.logDebugInfo("Player teleported to shop: " + isTeleported))
-
-        );
+        FindItemAddOn.getScheduler()
+                .teleportAsync(player, locToTeleport, PlayerTeleportEvent.TeleportCause.PLUGIN)
+                .thenAccept(isTeleported -> Logger.logDebugInfo("Player teleported to shop: " + isTeleported));
     }
 
     public boolean hasPermission(Player player, String permission) {


### PR DESCRIPTION
The extra runAtEntity wrapper around teleport was redundant and could cause double scheduling. FoliaLib already routes teleportAsync correctly for Folia and non-Folia servers, so this keeps teleporting region-safe without the extra hop.

Also removes the stale Folia TODO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal teleportation handling for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->