### PR TITLE
fix(folia): teleporting to shops on folia

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,5 +465,12 @@
             <version>3.7.3</version>
             <scope>provided</scope>
         </dependency>
+        <!-- For @Nullable on generics type -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/myzticbean/finditemaddon/handlers/gui/menus/FoundShopsMenu.java
+++ b/src/main/java/io/myzticbean/finditemaddon/handlers/gui/menus/FoundShopsMenu.java
@@ -210,23 +210,24 @@ public class FoundShopsMenu extends PaginatedMenu {
             }
 
             // Find a safe location around the shop
-            Location locToTeleport = LocationUtils.findSafeLocationAroundShop(shopLocation, player);
-            if (locToTeleport == null) {
-                sendUnsafeAreaMessage(player);
-                return;
-            }
+            LocationUtils.findSafeLocationAroundShop(shopLocation, player).thenAccept(locToTeleport -> {
+                if (locToTeleport == null) {
+                    sendUnsafeAreaMessage(player);
+                    return;
+                }
 
-            // Record the visit and set last location for Essentials
-            ShopSearchActivityStorageUtil.addPlayerVisitEntryAsync(shopLocation, player);
-            if (EssentialsXPlugin.isEnabled())
-                EssentialsXPlugin.setLastLocation(player);
+                // Record the visit and set last location for Essentials
+                ShopSearchActivityStorageUtil.addPlayerVisitEntryAsync(shopLocation, player);
+                if (EssentialsXPlugin.isEnabled())
+                    EssentialsXPlugin.setLastLocation(player);
 
-            // Apply teleport delay if necessary, otherwise teleport immediately
-            if (shouldApplyTeleportDelay(player)) {
-                applyTeleportDelay(player, locToTeleport);
-            } else {
-                PlayerUtil.teleport(player, locToTeleport);
-            }
+                // Apply teleport delay if necessary, otherwise teleport immediately
+                if (shouldApplyTeleportDelay(player)) {
+                    applyTeleportDelay(player, locToTeleport);
+                } else {
+                    PlayerUtil.teleport(player, locToTeleport);
+                }
+            });
         });
     }
 

--- a/src/main/java/io/myzticbean/finditemaddon/utils/LocationUtils.java
+++ b/src/main/java/io/myzticbean/finditemaddon/utils/LocationUtils.java
@@ -26,13 +26,13 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -126,9 +126,10 @@ public class LocationUtils {
         nonSuffocatingBlocks.add(Material.PISTON_HEAD);
     }
 
-    @Nullable
-    public static Location findSafeLocationAroundShop(Location shopLocation, Player player) {
+
+    public static CompletableFuture<@org.jspecify.annotations.Nullable Location> findSafeLocationAroundShop(Location shopLocation, Player player) {
         Logger.logDebugInfo("Finding safe location around the shop");
+        CompletableFuture<@org.jspecify.annotations.Nullable Location> future = new CompletableFuture<>();
         Location roundedShopLoc = getRoundedDestination(shopLocation);
         Logger.logDebugInfo("Rounded location: " + roundedShopLoc.getX() + ", " + roundedShopLoc.getY() + ", " + roundedShopLoc.getZ());
         // Creating a list of four block locations in 4 sides of the shop
@@ -157,64 +158,23 @@ public class LocationUtils {
                 roundedShopLoc.getY(),
                 roundedShopLoc.getZ() - 1
         ));
-        for(Location possibleSafeLoc : possibleSafeLocList) {
-            Logger.logDebugInfo("Possible safe location: " + possibleSafeLoc.getX() + ", " + possibleSafeLoc.getY() + ", " + possibleSafeLoc.getZ());
-            if(possibleSafeLoc.getBlock().getType().equals(FindItemAddOn.getQsApiInstance().getShopSignMaterial())
-                || walledSignBlocks.contains(possibleSafeLoc.getBlock().getType())) {
-                Logger.logDebugInfo("Shop sign block found at " + possibleSafeLoc.getX() + ", " + possibleSafeLoc.getY() + ", " + possibleSafeLoc.getZ());
-                // Adding a check for a safe location check bypass permission
-                if(PlayerUtil.hasPermission(player, PlayerPermsEnum.FINDITEM_SHOPTP_BYPASS_SAFETYCHECK.value())) {
-                    Location blockBelow = new Location(
-                            possibleSafeLoc.getWorld(),
-                            possibleSafeLoc.getBlockX(),
-                            possibleSafeLoc.getBlockY() - 1,
-                            possibleSafeLoc.getBlockZ()
-                    );
-                    possibleSafeLoc = lookAt(getRoundedDestination(new Location(
-                                blockBelow.getWorld(),
-                                blockBelow.getX(),
-                                blockBelow.getY() + 1,
-                                blockBelow.getZ()
-                        )
-                    ), roundedShopLoc);
-                    return possibleSafeLoc;
-                }
-                // check if the block above is suffocating
-                Location blockAbove = new Location(
-                        possibleSafeLoc.getWorld(),
-                        possibleSafeLoc.getBlockX(),
-                        possibleSafeLoc.getBlockY() + 1,
-                        possibleSafeLoc.getBlockZ());
-                Logger.logDebugInfo("Block above shop sign: " + blockAbove.getX() + ", " + blockAbove.getY() + ", " + blockAbove.getZ());
-                if(!isBlockSuffocating(blockAbove)) {
-                    Location blockBelow = null;
-                    boolean safeLocFound = false;
-                    for(int i = 1; i <= BELOW_SAFE_BLOCK_CHECK_LIMIT; i++) {
-                        blockBelow = new Location(
+        for(Location finalPossibleSafeLoc : possibleSafeLocList) {
+            Logger.logDebugInfo("Possible safe location: " + finalPossibleSafeLoc.getX() + ", " + finalPossibleSafeLoc.getY() + ", " + finalPossibleSafeLoc.getZ());
+
+            FindItemAddOn.getScheduler().runAtLocation(finalPossibleSafeLoc, task -> {
+                Location possibleSafeLoc = finalPossibleSafeLoc;
+
+                if(possibleSafeLoc.getBlock().getType().equals(FindItemAddOn.getQsApiInstance().getShopSignMaterial())
+                        || walledSignBlocks.contains(possibleSafeLoc.getBlock().getType())) {
+                    Logger.logDebugInfo("Shop sign block found at " + possibleSafeLoc.getX() + ", " + possibleSafeLoc.getY() + ", " + possibleSafeLoc.getZ());
+                    // Adding a check for a safe location check bypass permission
+                    if(PlayerUtil.hasPermission(player, PlayerPermsEnum.FINDITEM_SHOPTP_BYPASS_SAFETYCHECK.value())) {
+                        Location blockBelow = new Location(
                                 possibleSafeLoc.getWorld(),
                                 possibleSafeLoc.getBlockX(),
-                                possibleSafeLoc.getBlockY() - i,
+                                possibleSafeLoc.getBlockY() - 1,
                                 possibleSafeLoc.getBlockZ()
                         );
-                        Logger.logDebugInfo("Block below shop sign: "
-                                + blockBelow.getBlock().getType() + " " + blockBelow.getX() + ", " + blockBelow.getY() + ", " + blockBelow.getZ());
-                        if(blockBelow.getBlock().getType().equals(Material.AIR)
-                            || blockBelow.getBlock().getType().equals(Material.CAVE_AIR)
-                            || blockBelow.getBlock().getType().equals(Material.VOID_AIR)
-                            || blockBelow.getBlock().getType().equals(FindItemAddOn.getQsApiInstance().getShopSignMaterial())) {
-                            // do nothing and let the loop run
-                            Logger.logDebugInfo("Shop or Air found below");
-                        }
-                        else if(!isBlockDamaging(blockBelow)) {
-                            Logger.logDebugInfo("Safe block found!");
-                            safeLocFound = true;
-                            break;
-                        }
-                        else {
-                            break;
-                        }
-                    }
-                    if(safeLocFound) {
                         possibleSafeLoc = lookAt(getRoundedDestination(new Location(
                                         blockBelow.getWorld(),
                                         blockBelow.getX(),
@@ -222,24 +182,74 @@ public class LocationUtils {
                                         blockBelow.getZ()
                                 )
                         ), roundedShopLoc);
-                        Logger.logDebugInfo("Safe location found: " + possibleSafeLoc.getX() + ", " + possibleSafeLoc.getY() + ", " + possibleSafeLoc.getZ());
-                        return possibleSafeLoc;
+                        future.complete(possibleSafeLoc);
+                        return;
+                    }
+                    // check if the block above is suffocating
+                    Location blockAbove = new Location(
+                            possibleSafeLoc.getWorld(),
+                            possibleSafeLoc.getBlockX(),
+                            possibleSafeLoc.getBlockY() + 1,
+                            possibleSafeLoc.getBlockZ());
+                    Logger.logDebugInfo("Block above shop sign: " + blockAbove.getX() + ", " + blockAbove.getY() + ", " + blockAbove.getZ());
+                    if(!isBlockSuffocating(blockAbove)) {
+                        Location blockBelow = null;
+                        boolean safeLocFound = false;
+                        for(int i = 1; i <= BELOW_SAFE_BLOCK_CHECK_LIMIT; i++) {
+                            blockBelow = new Location(
+                                    possibleSafeLoc.getWorld(),
+                                    possibleSafeLoc.getBlockX(),
+                                    possibleSafeLoc.getBlockY() - i,
+                                    possibleSafeLoc.getBlockZ()
+                            );
+                            Logger.logDebugInfo("Block below shop sign: "
+                                    + blockBelow.getBlock().getType() + " " + blockBelow.getX() + ", " + blockBelow.getY() + ", " + blockBelow.getZ());
+                            if(blockBelow.getBlock().getType().equals(Material.AIR)
+                                    || blockBelow.getBlock().getType().equals(Material.CAVE_AIR)
+                                    || blockBelow.getBlock().getType().equals(Material.VOID_AIR)
+                                    || blockBelow.getBlock().getType().equals(FindItemAddOn.getQsApiInstance().getShopSignMaterial())) {
+                                // do nothing and let the loop run
+                                Logger.logDebugInfo("Shop or Air found below");
+                            }
+                            else if(!isBlockDamaging(blockBelow)) {
+                                Logger.logDebugInfo("Safe block found!");
+                                safeLocFound = true;
+                                break;
+                            }
+                            else {
+                                break;
+                            }
+                        }
+                        if(safeLocFound) {
+                            possibleSafeLoc = lookAt(getRoundedDestination(new Location(
+                                            blockBelow.getWorld(),
+                                            blockBelow.getX(),
+                                            blockBelow.getY() + 1,
+                                            blockBelow.getZ()
+                                    )
+                            ), roundedShopLoc);
+                            Logger.logDebugInfo("Safe location found: " + possibleSafeLoc.getX() + ", " + possibleSafeLoc.getY() + ", " + possibleSafeLoc.getZ());
+                            future.complete(possibleSafeLoc);
+                            return;
+                        }
+                        else {
+                            future.complete(null);
+                            return;
+                        }
                     }
                     else {
-                        return null;
+                        Logger.logDebugInfo("Block above shop sign found not air. Block type: " + blockAbove.getBlock().getType());
+                        future.complete(null);
+                        return;
                     }
                 }
                 else {
-                    Logger.logDebugInfo("Block above shop sign found not air. Block type: " + blockAbove.getBlock().getType());
-                    return null;
+                    Logger.logDebugInfo("Block not shop sign. Block type: " + possibleSafeLoc.getBlock().getType());
                 }
-            }
-            else {
-                Logger.logDebugInfo("Block not shop sign. Block type: " + possibleSafeLoc.getBlock().getType());
-            }
+            });
         }
         Logger.logDebugInfo("No safe block found near shop");
-        return null;
+        return future;
     }
 
     // Found the below function from this thread: https://bukkit.org/threads/lookat-and-move-functions.26768/


### PR DESCRIPTION
There was an uncaught exception being swallowed somewhere in that method: 

```log
[02:14:02 ERROR]: Could not pass event InventoryClickEvent to QSFindItemAddOn v2.0.7.7-RELEASE
java.lang.IllegalStateException: World mismatch: expected main but got main_seasons
        at net.minecraft.world.level.Level.getCurrentWorldData(Level.java:823) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.world.level.Level.getBlockState(Level.java:1329) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at org.bukkit.craftbukkit.block.CraftBlock.getType(CraftBlock.java:245) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at QSFindItemAddOn-2.0.7.7-RELEASE-1772867634221.jar//io.myzticbean.finditemaddon.utils.LocationUtils.findSafeLocationAroundShop(LocationUtils.java:140) ~[?:?]
        at QSFindItemAddOn-2.0.7.7-RELEASE-1772867634221.jar//io.myzticbean.finditemaddon.handlers.gui.menus.FoundShopsMenu.handleDirectShopTeleport(FoundShopsMenu.java:212) ~[?:?]
        at QSFindItemAddOn-2.0.7.7-RELEASE-1772867634221.jar//io.myzticbean.finditemaddon.handlers.gui.menus.FoundShopsMenu.handleShopItemClick(FoundShopsMenu.java:173) ~[?:?]
        at QSFindItemAddOn-2.0.7.7-RELEASE-1772867634221.jar//io.myzticbean.finditemaddon.handlers.gui.menus.FoundShopsMenu.handleMenu(FoundShopsMenu.java:119) ~[?:?]
        at QSFindItemAddOn-2.0.7.7-RELEASE-1772867634221.jar//io.myzticbean.finditemaddon.listeners.MenuListener.onMenuClick(MenuListener.java:40) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:57) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3379) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:59) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:86) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:39) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1647) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:459) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:520) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:533) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at io.canvasmc.canvas.tick.CRSThreadPool$TickThreadRunner.run(CRSThreadPool.java:714) ~[canvas-1.21.11.jar:1.21.11-644-f6ec1c5]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server responsiveness during shop teleportation by making location-finding operations non-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->