### PR TITLE
chore: update version to 2.0.8.0-RELEASE, add claude-code setup

### DIFF
--- a/.claude/skills/bukkit-developer/SKILL.md
+++ b/.claude/skills/bukkit-developer/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: minecraft-bukkit-pro
+description: Master Minecraft server plugin development with Bukkit, Spigot, and Paper APIs.
+risk: safe
+source: community
+date_added: '2026-02-27'
+---
+
+## Use this skill when
+
+- Working on minecraft bukkit pro tasks or workflows
+- Needing guidance, best practices, or checklists for minecraft bukkit pro
+
+## Do not use this skill when
+
+- The task is unrelated to minecraft bukkit pro
+- You need a different domain or tool outside this scope
+
+## Instructions
+
+- Clarify goals, constraints, and required inputs.
+- Apply relevant best practices and validate outcomes.
+- Provide actionable steps and verification.
+- If detailed examples are required, open `resources/implementation-playbook.md`.
+
+You are a Minecraft plugin development master specializing in Bukkit, Spigot, and Paper server APIs with deep knowledge of internal mechanics and modern development patterns.
+
+## Core Expertise
+
+### API Mastery
+- Event-driven architecture with listener priorities and custom events
+- Modern Paper API features (Adventure, MiniMessage, Lifecycle API)
+- Command systems using Brigadier framework and tab completion
+- Inventory GUI systems with NBT manipulation
+- World generation and chunk management
+- Entity AI and pathfinding customization
+
+### Internal Mechanics
+- NMS (net.minecraft.server) internals and Mojang mappings
+- Packet manipulation and protocol handling
+- Reflection patterns for cross-version compatibility
+- Paperweight-userdev for deobfuscated development
+- Custom entity implementations and behaviors
+- Server tick optimization and timing analysis
+
+### Performance Engineering
+- Hot event optimization (PlayerMoveEvent, BlockPhysicsEvent)
+- Async operations for I/O and database queries
+- Chunk loading strategies and region file management
+- Memory profiling and garbage collection tuning
+- Thread pool management and concurrent collections
+- Spark profiler integration for production debugging
+
+### Ecosystem Integration
+- Vault, PlaceholderAPI, ProtocolLib advanced usage
+- Database systems (MySQL, Redis, MongoDB) with HikariCP
+- Message queue integration for network communication
+- Web API integration and webhook systems
+- Cross-server synchronization patterns
+- Docker deployment and Kubernetes orchestration
+
+## Development Philosophy
+
+1. **Research First**: Always use WebSearch for current best practices and existing solutions
+2. **Architecture Matters**: Design with SOLID principles and design patterns
+3. **Performance Critical**: Profile before optimizing, measure impact
+4. **Version Awareness**: Detect server type (Bukkit/Spigot/Paper) and use appropriate APIs
+5. **Modern When Possible**: Use modern APIs when available, with fallbacks for compatibility
+6. **Test Everything**: Unit tests with MockBukkit, integration tests on real servers
+
+## Technical Approach
+
+### Project Analysis
+- Examine build configuration for dependencies and target versions
+- Identify existing patterns and architectural decisions
+- Assess performance requirements and scalability needs
+- Review security implications and attack vectors
+
+### Implementation Strategy
+- Start with minimal viable functionality
+- Layer in features with proper separation of concerns
+- Implement comprehensive error handling and recovery
+- Add metrics and monitoring hooks
+- Document with JavaDoc and user guides
+
+### Quality Standards
+- Follow Google Java Style Guide
+- Implement defensive programming practices
+- Use immutable objects and builder patterns
+- Apply dependency injection where appropriate
+- Maintain backward compatibility when possible
+
+## Output Excellence
+
+### Code Structure
+- Clean package organization by feature
+- Service layer for business logic
+- Repository pattern for data access
+- Factory pattern for object creation
+- Event bus for internal communication
+
+### Configuration
+- YAML with detailed comments and examples
+- Version-appropriate text formatting (MiniMessage for Paper, legacy for Bukkit/Spigot)
+- Gradual migration paths for config updates
+- Environment variable support for containers
+- Feature flags for experimental functionality
+
+### Build System
+- Maven/Gradle with proper dependency management
+- Shade/shadow for dependency relocation
+- Multi-module projects for version abstraction
+- CI/CD integration with automated testing
+- Semantic versioning and changelog generation
+
+### Documentation
+- Comprehensive README with quick start
+- Wiki documentation for advanced features
+- API documentation for developer extensions
+- Migration guides for version updates
+- Performance tuning guidelines
+
+Always leverage WebSearch and WebFetch to ensure best practices and find existing solutions. Research API changes, version differences, and community patterns before implementing. Prioritize maintainable, performant code that respects server resources and player experience.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,19 @@
 - Added debug mode control via command: `/finditemadmin debug-mode {enable | disable}`
 - Bumped Paper API version to `1.21.11-R0.1-SNAPSHOT`
 - Bumped Kyori's `adventure-api` to 4.26.1
-- Bumped `worldguard-bukkit` to 7.0.14
-- Bumped `playerwarps-api` to 7.9.0
+- Bumped `worldguard-bukkit` to 7.0.16
+- Bumped `playerwarps-api` to 7.10.0
 - Removed Spigot API dependency
 - Bumped `Quickshop-Hikari` to 6.2.0.11
 - Folia support [#91] by Jsinco
+- Bumped `essentialsX` to 2.21.2
 
 ### Known issues
 - Teleportation is broken on Folia servers
 
 ### Bug fixes
 - Fixed a bug during loadShopsFromFile if one of the loaded shops was null by adding a null check
+- Bug fix for update checker, notify snapshot version availability for snapshot users only (#102)
 
 ## Release 2.0.7.7
 ### Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Bukkit/Paper plugin that adds a `/finditem` command for searching items across all QuickShop-Hikari shops on a Minecraft server. Also exposes `/finditemadmin` (alias `/fiadmin`) for reload/debug. Java 21, built with Maven, shaded into a single jar. Paper 1.20+ API, with Folia support via FoliaLib.
+
+## Build & Run
+
+- Build: `mvn clean package` — produces the shaded jar in `target/`.
+- There are **no unit tests** in this repository; `mvn test` is a no-op. Verification is done by dropping the jar into a Paper/Folia server with QuickShop-Hikari installed.
+- `maven-shade-plugin` relocates `com.tcoded.folialib` → `io.myzticbean.finditemaddon.shaded.folialib` and `org.bstats` → `...shaded.metrics`. Never reference unshaded packages in new code.
+- `pom.xml` has commented-out `<outputDirectory>` entries in `maven-jar-plugin` intended to auto-copy the jar into a local test server's `plugins/` folder — uncomment the relevant one for your OS when iterating locally.
+- One system-scope dependency lives in `lib/Residence5.1.5.1.jar` (not on any Maven repo) — keep that file in place.
+- Version in `pom.xml` and the snapshot build date are edited manually; `plugin.yml` picks up `${project.version}` via resource filtering.
+
+## Architecture
+
+### Entry point
+`io.myzticbean.finditemaddon.FindItemAddOn` (extends `JavaPlugin`) orchestrates the lifecycle:
+1. `onLoad` — initializes `FoliaLib` (all scheduling must go through `FindItemAddOn.getScheduler()`, never `Bukkit.getScheduler()` directly, or Folia will crash).
+2. `onEnable` — registers Bukkit listeners, loads config (`ConfigSetup` + `ConfigProvider`), registers commands via SimpAPI's `CommandManager`, then defers the rest to `runPluginStartupTasks()` on the next tick so dependencies have finished enabling.
+3. `runPluginStartupTasks` — hard-requires QuickShop-Hikari, instantiates the `QSApi` impl, loads `shops.json`, sets up optional integrations, registers the 15-min async task, bStats, and the update checker.
+
+### QuickShop abstraction
+`quickshop/QSApi.java` is a generic interface (`QSApi<SHOP, PLAYER>`) over the shop plugin. Only `QSHikariAPIHandler` is active; `QSReremakeAPIHandler` is dead code retained for reference (Reremake support was dropped). All shop queries (search-to-buy, search-to-sell, material filters, stock checks, enchantment/potion metadata) go through this interface. When touching shop logic, add methods on `QSApi` and implement in `QSHikariAPIHandler` — do **not** call QuickShop APIs from command/GUI code directly.
+
+### Commands
+Built on `me.kodysimpson.simpapi.command.CommandManager` (SimpAPI). Subcommand classes in `commands/simpapi/` (`BuySubCmd`, `SellSubCmd`, `HideShopSubCmd`, `RevealShopSubCmd`, `ReloadSubCmd`, `DebugSubCmd`) are registered by reflection via `CommandManager.createCoreCommand`. The `hide`/`reveal` subcommands are conditionally included based on `FIND_ITEM_CMD_REMOVE_HIDE_REVEAL_SUBCMDS`. There is also a `commands/quickshop/` package that registers a subcommand directly under `/qs` via `QSApi.registerSubCommand()`.
+
+### GUI
+`handlers/gui/Menu.java` + `PaginatedMenu.java` are the inventory-based GUI base classes; concrete menus live in `handlers/gui/menus/`. Per-player state is stored in a `PlayerMenuUtility` retrieved via `FindItemAddOn.getPlayerMenuUtility(Player)` — this is the channel for passing search results between the command handler, menus, and click handlers. `MenuListener` dispatches `InventoryClickEvent` to the active menu.
+
+### Persistence
+Hidden/visited-shop state is serialized to JSON under the plugin data folder by `utils/json/ShopSearchActivityStorageUtil` (Jackson with `jsr310`). On startup, `migrateHiddenShopsToShopsJson()` migrates the pre-2.0 `hiddenShops.json` format — keep this migration intact. `onDisable` saves the file.
+
+### Optional integrations
+Each lives in `dependencies/` as a static setup-and-check class: `PlayerWarpsPlugin`, `EssentialsXPlugin`, `WGPlugin` (WorldGuard), `ResidencePlugin`, `BentoBoxPlugin`, plus GriefPrevention support in utils. The pattern is: `setup()` checks `Bukkit.getPluginManager()`, caches the API handle, and sets an `isEnabled` flag. Always gate integration code behind that flag. EssentialsX warps are refreshed on a 15-minute schedule (`scheduledtasks/Task15MinInterval`) because per-query lookups are too expensive.
+
+### Concurrency
+- Scheduling: always via `FindItemAddOn.getScheduler()` (FoliaLib `PlatformScheduler`) — `runNextTick`, `runTimerAsync`, region-aware variants. Never use raw Bukkit scheduler.
+- Heavy, non-Bukkit work (search aggregation, HTTP) goes through `utils/async/VirtualThreadScheduler` (shut down in `onDisable`).
+- Any call that touches a shop's block / chunk / location on Folia must be wrapped in the scheduler's region task.
+
+### Config
+`config/ConfigSetup` handles file creation, missing-key backfill, and writing out `sample-config.yml`. `config/ConfigProvider` is the typed accessor used throughout the code (`FindItemAddOn.getConfigProvider().SOME_KEY`). When adding a config option: add the field + parse logic in `ConfigProvider`, add the default to `resources/config.yml`, and update `ConfigSetup.checkForMissingProperties()` so existing installs get the new key.
+
+## Conventions (from .windsurfrules)
+
+- PascalCase classes, camelCase methods/variables, ALL_CAPS constants.
+- Lombok is available and used (`@Getter`, `@Slf4j`) — prefer it over hand-written boilerplate.
+- Logging goes through `utils/log/Logger` (`logInfo`, `logWarning`, `logError`), not `System.out` or raw `getLogger()`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Shop Search AddOn For QuickShop
-### Version: 2.0.8.0-SNAPSHOT-260308
+### Version: 2.0.8.0-RELEASE
 
 An unofficial add-on for the QuickShop Hikari and Reremake spigot plugin.
 Adds a `/finditem` command in game for searching through all the shops on the server.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.myzticbean.finditemaddon</groupId>
     <artifactId>QSFindItemAddOn</artifactId>
-    <version>2.0.8.0-SNAPSHOT-260308</version>
+    <version>2.0.8.0-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>QSFindItemAddOn</name>
@@ -18,9 +18,9 @@
         <paper-api.version>1.21.11-R0.1-SNAPSHOT</paper-api.version>
         <qs-hikari.version>6.2.0.11</qs-hikari.version>
         <playerwarps-api-old>6.30.0</playerwarps-api-old>
-        <playerwarps-api-new>7.9.0</playerwarps-api-new>
-        <essentialsx.version>2.21.1</essentialsx.version>
-        <worldguard-bukkit.version>7.0.14</worldguard-bukkit.version>
+        <playerwarps-api-new>7.10.0</playerwarps-api-new>
+        <essentialsx.version>2.21.2</essentialsx.version>
+        <worldguard-bukkit.version>7.0.16</worldguard-bukkit.version>
         <jackson.version>2.21.0</jackson.version>
     </properties>
 
@@ -312,18 +312,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.olziedev</groupId>
-            <artifactId>playerwarps-api</artifactId>
-            <version>${playerwarps-api-old}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.olziedev</groupId>-->
+<!--            <artifactId>playerwarps-api</artifactId>-->
+<!--            <version>${playerwarps-api-old}</version>-->
+<!--            <scope>provided</scope>-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>*</groupId>-->
+<!--                    <artifactId>*</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>com.olziedev</groupId>
             <artifactId>playerwarps-api</artifactId>

--- a/src/main/java/io/myzticbean/finditemaddon/dependencies/BentoBoxPlugin.java
+++ b/src/main/java/io/myzticbean/finditemaddon/dependencies/BentoBoxPlugin.java
@@ -1,3 +1,21 @@
+/**
+ * QSFindItemAddOn: An Minecraft add-on plugin for the QuickShop Hikari
+ * and Reremake Shop plugins for Spigot server platform.
+ * Copyright (C) 2021  myzticbean
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.myzticbean.finditemaddon.dependencies;
 
 import org.bukkit.Bukkit;

--- a/src/main/java/io/myzticbean/finditemaddon/utils/PlayerUtil.java
+++ b/src/main/java/io/myzticbean/finditemaddon/utils/PlayerUtil.java
@@ -1,3 +1,21 @@
+/**
+ * QSFindItemAddOn: An Minecraft add-on plugin for the QuickShop Hikari
+ * and Reremake Shop plugins for Spigot server platform.
+ * Copyright (C) 2021  myzticbean
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.myzticbean.finditemaddon.utils;
 
 import io.myzticbean.finditemaddon.FindItemAddOn;

--- a/src/main/java/io/myzticbean/finditemaddon/utils/UpdateChecker.java
+++ b/src/main/java/io/myzticbean/finditemaddon/utils/UpdateChecker.java
@@ -60,18 +60,24 @@ public class UpdateChecker {
                 updateAvailabilityConsumer.accept(false);
                 return;
             }
-            var latestVersionDetails = projectVersions.getFirst();
-            if (latestVersionDetails == null || latestVersionDetails.getVersionNumber() == null) {
-                Logger.logWarning("Invalid version response from Modrinth");
+            var currentVersion = FindItemAddOn.getInstance().getDescription().getVersion();
+            boolean currentIsSnapshot = isSnapshotVersion(currentVersion);
+            var latestVersionDetails = projectVersions.stream()
+                    .filter(v -> v != null && v.getVersionNumber() != null)
+                    .filter(v -> isSnapshotVersion(v.getVersionNumber()) == currentIsSnapshot)
+                    .findFirst()
+                    .orElse(null);
+            if (latestVersionDetails == null) {
+                Logger.logWarning("No matching " + (currentIsSnapshot ? "snapshot" : "release")
+                        + " version found on Modrinth");
                 updateAvailabilityConsumer.accept(false);
                 return;
             }
             var latestVersion = latestVersionDetails.getVersionNumber();
-            var currentVersion = FindItemAddOn.getInstance().getDescription().getVersion();
             boolean isUpToDate = currentVersion.equals(latestVersion);
             updateAvailabilityConsumer.accept(!isUpToDate);
             if (!isUpToDate) {
-                if(latestVersion.toLowerCase().contains("snapshot")) {
+                if (currentIsSnapshot) {
                     Logger.logWarning("Plugin has a new snapshot version available! (Version: " + latestVersion + ")");
                 } else {
                     Logger.logWarning("Plugin has a new update available! (Version: " + latestVersion + ")");
@@ -79,6 +85,14 @@ public class UpdateChecker {
                 Logger.logWarning("Download here: https://modrinth.com/plugin/shop-search/version/" + latestVersion);
             }
         });
+    }
+
+    /**
+     * Determines if a version string represents a SNAPSHOT build.
+     * Expected formats: {@code 2.0.8.0-SNAPSHOT}, {@code 2.0.8.0-SNAPSHOT-<date>} or {@code 2.0.8.0-RELEASE}.
+     */
+    private static boolean isSnapshotVersion(String version) {
+        return version != null && version.toUpperCase().contains("-SNAPSHOT");
     }
 
     @Deprecated(since = "v2.0.7.7")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update checker now correctly notifies snapshot users about snapshot version availability

* **Chores**
  * Released as version 2.0.8.0-RELEASE
  * Updated dependencies: playerwarps-api to 7.10.0, essentialsx to 2.21.2, and worldguard-bukkit to 7.0.16

<!-- end of auto-generated comment: release notes by coderabbit.ai -->